### PR TITLE
Update test.yml - add node 20.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 16.x, 18.x ]
+        node-version: [ 16.x, 18.x, 20.x]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:


### PR DESCRIPTION
Please consider adding node 20.x to you test matrix ad node 20.x is already released and used by part of ioBroker community.

If node 20.x causes any problems with your adapter, feel free to omit it from tests for now but create a issue describing the problem and try to fix it as soon as your time allows.

Thanks a lot for supporting ioBroker.
mcm1957