### PR TITLE
ci: switch to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ioBroker/testing-action-check@master
+      - uses: ioBroker/testing-action-check@v1
         with:
           node-version: 22.x
           install-command: 'corepack enable && yarn install'

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ioBroker/testing-action-check@master
+      - uses: ioBroker/testing-action-check@v1
         with:
           node-version: 22.x
           install-command: 'corepack enable && yarn install'


### PR DESCRIPTION
Fixed by: https://github.com/ioBroker/testing-action-check/issues/6
After the test-command was fixed in latest
version we can switch back to v1